### PR TITLE
Module sugar methods

### DIFF
--- a/lib/nano_ring.ex
+++ b/lib/nano_ring.ex
@@ -61,7 +61,7 @@ defmodule NanoRing do
   def del_node(node) when is_binary(node), do: del_node(binary_to_atom(node))
   def del_node(node) when is_atom(node), do: :gen_server.cast(__MODULE__, { :del_node, node })
 
-  def update_ring(old_ring,new_ring) do
+  defp update_ring(old_ring,new_ring) do
     case {old_ring.up_set|>Enum.reduce(HashSet.new,&Set.put(&2,&1)),new_ring.up_set|>Enum.reduce(HashSet.new,&Set.put(&2,&1))} do
       {unchanged,unchanged}->:nothingtodo
       {old_up_set,new_up_set}->:gen_event.notify(NanoRing.Events,{:new_up_set,old_up_set,new_up_set})


### PR DESCRIPTION
I've added some "sugar" methods to call/cast the NanoRing more easily:

``` elixir
NanoRing.all
NanoRing.up
NanoRing.add_node("node@node")
NanoRing.add_node(:"node@node")
NanoRing.del_node("node@node")
NanoRing.del_node(:"node@node")
```

I've also made `update_ring/2` a private method.

What do you think?
